### PR TITLE
Fix NFC tool display

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -2,7 +2,7 @@ import { Tabs } from 'expo-router';
 import { Platform } from 'react-native';
 import { Scan, History, Settings, BookMarked } from 'lucide-react-native';
 import { TabBar } from '../styles';
-
+import ScanScreen from '../screens/index';
 
 export default function TabLayout() {
   return (
@@ -40,6 +40,14 @@ export default function TabLayout() {
           title: 'Settings',
           tabBarIcon: ({ color, size }) => <Settings size={size} color={color} />,
         }}
+      />
+      <Tabs.Screen
+        name="ScanScreen"
+        options={{
+          title: 'NFC Tool',
+          tabBarIcon: ({ color, size }) => <Scan size={size} color={color} />,
+        }}
+        component={ScanScreen}
       />
     </Tabs>
   );

--- a/app/App.js
+++ b/app/App.js
@@ -1,7 +1,7 @@
 import 'react-native-gesture-handler';
 import { registerRootComponent } from 'expo';
-import App from "./(tabs)";
+import ScanScreen from "./screens/index";
 
-registerRootComponent(App);
+registerRootComponent(ScanScreen);
 
-export default App;
+export default ScanScreen;

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,6 +3,7 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
+import ScanScreen from '../screens/index';
 
 declare global {
   interface Window {
@@ -19,7 +20,7 @@ export default function RootLayout() {
     <>
       <Header />
       <Stack screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="+not-found" />
+        <Stack.Screen name="ScanScreen" component={ScanScreen} />
       </Stack>
       <Footer />
       <StatusBar style="auto" />


### PR DESCRIPTION
Update the app to display the NFC tool instead of the default message.

* **app/App.js**
  - Import `ScanScreen` from `app/screens/index.tsx` instead of `App` from `app/(tabs)`.
  - Update the `registerRootComponent` call to use `ScanScreen` instead of `App`.
  - Export `ScanScreen` instead of `App`.

* **app/_layout.tsx**
  - Import `ScanScreen` from `app/screens/index.tsx`.
  - Replace the `Stack.Screen` component with `ScanScreen`.

* **app/(tabs)/_layout.tsx**
  - Import `ScanScreen` from `app/screens/index.tsx`.
  - Add a new `Tabs.Screen` component for `ScanScreen`.

